### PR TITLE
Fixing bug introduced by default of fractional coordinates.

### DIFF
--- a/seamm_ff_util/forcefield.py
+++ b/seamm_ff_util/forcefield.py
@@ -2788,7 +2788,9 @@ class Forcefield(object):
     def eex_atoms(self, eex, system, configuration=None):
         """List the atoms into the energy expression"""
         atoms = system['atom']
-        coordinates = atoms.coordinates(configuration=configuration)
+        coordinates = atoms.coordinates(
+            configuration=configuration, fractionals=False
+        )
         key = f'atom_types_{self.current_forcefield}'
         types = atoms.get_column(key, configuration=configuration)
 


### PR DESCRIPTION
Now explicitly request Cartesians for the LAMMPS energy expression