### PR TITLE
Support for local forcefield files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,15 @@
 =======
 History
 =======
-
+2024.6.27 -- Support for local forcefield files
+   * Added support for local forcefields files which can either be used directly
+     or included by existing files.
+   * Added URI handler to support local files
+   * Added support for BibTex references in forcefield files, and automatically adding
+     citations to the Reference Handler.
+   * Add 'fragments' section to forcefields for atom-typing via a fragment or entire
+     molecule. This supports using LigParGen for OPLS-AA forcefields.
+     
 2023.8.27 -- Added support for tabulated angle potentials
 
 2023.4.6 -- Added support for Buckingham potentials

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,6 +12,7 @@ dependencies:
   - molsystem
   - numpy
   - packaging
+  - rdkit
   - seamm-util
   - sympy
 

--- a/seamm_ff_util/ff_assigner.py
+++ b/seamm_ff_util/ff_assigner.py
@@ -3,6 +3,7 @@
 """Main class for handling forcefields"""
 
 import logging
+
 import rdkit
 import rdkit.Chem
 import rdkit.Chem.Draw
@@ -24,13 +25,49 @@ class FFAssigner(object):
 
         self.forcefield = forcefield
 
-    def assign(self, configuration):
+    def assign(self, configuration, picture=False):
         """Assign the atom types to the structure using SMARTS templates"""
         molecule = configuration.to_RDKMol()
 
         n_atoms = configuration.n_atoms
 
         atom_types = ["?"] * n_atoms
+
+        # First try the fragments, if any
+        fragments = self.forcefield.get_fragments()
+        for smiles, data in fragments.items():
+            smarts = data["SMARTS"]
+
+            pattern = rdkit.Chem.MolFromSmarts(smarts)
+
+            matches = molecule.GetSubstructMatches(pattern, maxMatches=6 * n_atoms)
+            logger.debug(smiles + ": ")
+            if len(matches) > 0:
+                for match in matches:
+                    for _type, atom in zip(data["atom types"], match):
+                        # Check if this has already been assigned to another fragment
+                        if atom_types[atom] != "?":
+                            key1 = atom_types[atom].split("_")[0]
+                            key2 = _type.split("_")[0]
+                            if key2 != key1:
+                                self.draw_atom_types(
+                                    molecule,
+                                    atom_types,
+                                    filename="duplicate_atom_types.png",
+                                )
+                                msg = (
+                                    f"Error in fragment atom typing: atom {atom} "
+                                    f"already typed:\n{atom_types[atom]}\n"
+                                    f"New assignment: {_type}"
+                                )
+                                logger.error(msg)
+                                raise RuntimeError(msg)
+                        atom_types[atom] = _type
+
+        # Fragments have priority, so don't change their assignments
+        assigned = [type_ != "?" for type_ in atom_types]
+
+        # And now the templates for the atom_types
         templates = self.forcefield.get_templates()
         for atom_type in templates:
             template = templates[atom_type]
@@ -50,9 +87,14 @@ class FFAssigner(object):
                     for match in matches:
                         atom_ids = [match[x] for x in map_list]
                         for x in atom_ids:
-                            atom_types[x] = atom_type
+                            if not assigned[x]:
+                                atom_types[x] = atom_type
                         tmp = [str(x) for x in atom_ids]
                         logger.debug("\t" + ", ".join(tmp))
+
+        # Create a picture with the atom types if requested
+        if picture:
+            self.draw_atom_types(molecule, atom_types)
 
         i = 0
         untyped = []
@@ -63,20 +105,63 @@ class FFAssigner(object):
             i += 1
 
         if len(untyped) > 0:
-            logger.warning(
+            msg = (
                 "The forcefield does not have atom types for"
                 " the molecule!. See missing_atom_types.png"
                 " for more detail."
             )
-            rdkit.Chem.AllChem.Compute2DCoords(molecule)
-            img = rdkit.Chem.Draw.MolToImage(
+            logger.error(msg)
+            self.draw_atom_types(
                 molecule,
-                size=(1000, 1000),
-                highlightAtoms=untyped,
-                highlightColor=(0, 1, 0),
+                atom_types,
+                filename="missing_atom_types.png",
+                highlight_atoms=untyped,
             )
-            img.save("missing_atom_types.png")
+            raise RuntimeError(msg)
         else:
             logger.info("The molecule was successfully atom-typed")
 
         return atom_types
+
+    def draw_atom_types(
+        self,
+        molecule,
+        atom_types,
+        legend=None,
+        filename="atom_types.png",
+        highlight_atoms=None,
+    ):
+        """Create a picture of the molecule labeled by atom types.
+
+        Parameters
+        ----------
+        molecule : rdkit.molecule
+            The molecule as an RDKit molecule.
+        atom_types : [str]
+            The labels for the atom types
+        legend : str
+            The legend for the picture. Defaults to "Atom types for ff_file:ffname"
+        filename : str or pathlib.Path
+            The file to write the picture to.
+        highlight_atoms : [int]
+            The atoms to highlight
+        """
+        if legend is None:
+            legend = (
+                f"Atom Types for {self.forcefield.filename}:"
+                f"{self.forcefield.current_forcefield}"
+            )
+
+        for atom, atom_type in zip(molecule.GetAtoms(), atom_types):
+            atom.SetProp("atomNote", atom_type)
+        rdkit.Chem.AllChem.Compute2DCoords(molecule)
+        rdkit.Chem.rdDepictor.StraightenDepiction(molecule)
+
+        d2d = rdkit.Chem.Draw.MolDraw2DCairo(1000, 1000)
+        dopts = d2d.drawOptions()
+        dopts.addAtomIndices = True
+        dopts.legendFontSize = 30
+
+        d2d.DrawMolecule(molecule, legend=legend, highlightAtoms=highlight_atoms)
+        d2d.FinishDrawing()
+        d2d.WriteDrawingText(filename)

--- a/seamm_ff_util/metadata.py
+++ b/seamm_ff_util/metadata.py
@@ -182,9 +182,9 @@ metadata = {
         "equation": [
             (
                 "  1/2 * V1 * [1 + cos(Phi)]"
-                "+ 1/2 * V2 * [1 - cos(Phi)]"
-                "+ 1/2 * V3 * [1 + cos(Phi)]"
-                "+ 1/2 * V4 * [1 - cos(Phi)]"
+                "+ 1/2 * V2 * [1 - cos(2*Phi)]"
+                "+ 1/2 * V3 * [1 + cos(3*Phi)]"
+                "+ 1/2 * V4 * [1 - cos(4*Phi)]"
             )
         ],
         "constants": [
@@ -192,6 +192,23 @@ metadata = {
             ("V2", "kcal/mol"),
             ("V3", "kcal/mol"),
             ("V4", "kcal/mol"),
+        ],
+        "topology": {
+            "type": "torsion",
+            "n_atoms": 4,
+            "symmetry": "like_torsion",
+            "fill": 0,
+            "flip": 0,
+        },
+    },
+    "torsion_fourier": {
+        "equation": [
+            "sum i=1,m {Ki *  [1 + cos(ni*Phi - Phi0i)]}",
+        ],
+        "constants": [
+            ("K", "kcal/mol"),
+            ("n", ""),
+            ("Phi0", "degree"),
         ],
         "topology": {
             "type": "torsion",
@@ -219,6 +236,19 @@ metadata = {
         "equation": ["1/2 * V2 * [1 - cos(Phi)]"],
         "constants": [
             ("V2", "kcal/mol"),
+        ],
+        "topology": {
+            "type": "out-of-plane",
+            "n_atoms": 4,
+            "symmetry": "like_improper",
+            "fill": 0,
+            "flip": 0,
+        },
+    },
+    "improper_harmonic": {
+        "equation": ["K2 * (Chi - Chi0)^2"],
+        "constants": [
+            ("K2", "kcal/mol"),
         ],
         "topology": {
             "type": "out-of-plane",

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
* Added support for local forcefields files which can either be used directly or included by existing files.
* Added URI handler to support local files
* Added support for BibTex references in forcefield files, and automatically adding citations to the Reference Handler.
* Add 'fragments' section to forcefields for atom-typing via a fragment or entire
     molecule. This supports using LigParGen for OPLS-AA forcefields.