### PR TITLE
Track more of the original parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2025.5.26 -- Track more of the original parameters
+   * Added tracking of the original parameters for cross terms like bond-bond terms.
+   * Improved chacking for duplicate parameters to remove most duplicates, except for
+     class 2 forcefields, where the cross terms must have the same terms as the
+     diagonal time, i.e. angle and bond-bond terms must share a list of angles.
+
 2025.5.23 -- Added charges in templates and tracking original parameters
    * Added charges in templates, which override any assignment from the bond increments
      or charges for the atom types.

--- a/seamm_ff_util/eex.py
+++ b/seamm_ff_util/eex.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import pprint  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -246,8 +247,8 @@ class EEX_Mixin:
                     real_types,
                 )
                 index = None
-                for value, count in zip(parameters, range(1, len(parameters) + 1)):
-                    if self.eex_compare_values(value, new_value):
+                for count, value in enumerate(parameters, start=1):
+                    if value == new_value:
                         index = count
                         break
                 if index is None:
@@ -417,7 +418,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -449,8 +450,9 @@ class EEX_Mixin:
                 parameters_type,
                 real_types,
             )
+            # if self.eex_compare_values(value, new_value):
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -483,7 +485,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -518,7 +520,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -553,7 +555,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -588,7 +590,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -623,7 +625,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -658,7 +660,7 @@ class EEX_Mixin:
                 real_types,
             )
             index = None
-            for value, count in zip(parameters, range(1, len(parameters) + 1)):
+            for count, value in enumerate(parameters, start=1):
                 if self.eex_compare_values(value, new_value):
                     index = count
                     break
@@ -673,7 +675,7 @@ class EEX_Mixin:
         """Create the angle-angle portion of the energy expression
 
         j is the vertex atom of the angles. For the angle-angle parameters
-        the bond j-k is the common bond, i.e. the angles are i-j-k and j-k l
+        the bond j-k is the common bond, i.e. the angles are i-j-k and j-k-l
         """
         types = self.topology["types"]
         oops = self.topology["oops"]
@@ -692,15 +694,21 @@ class EEX_Mixin:
             K1 = parameter_values["K"]
             Theta10 = parameter_values["Theta10"]
             Theta30 = parameter_values["Theta20"]
+            oK1 = parameter_values["original K"]
+            oTheta10 = parameter_values["original Theta10"]
+            oTheta30 = parameter_values["original Theta20"]
             tmp = self.angle_angle_parameters(
                 types[k], types[j], types[i], types[l], zero=True
             )[3]
             K2 = tmp["K"]
             Theta20 = tmp["Theta20"]
+            oK2 = tmp["original K"]
+            oTheta20 = tmp["original Theta20"]
             tmp = self.angle_angle_parameters(
                 types[i], types[j], types[l], types[k], zero=True
             )[3]
             K3 = tmp["K"]
+            oK3 = tmp["original K"]
             new_value = (
                 form,
                 {
@@ -710,6 +718,12 @@ class EEX_Mixin:
                     "Theta10": Theta10,
                     "Theta20": Theta20,
                     "Theta30": Theta30,
+                    "original K1": oK1,
+                    "original K2": oK2,
+                    "original K3": oK3,
+                    "original Theta10": oTheta10,
+                    "original Theta20": oTheta20,
+                    "original Theta30": oTheta30,
                 },
                 (types[i], types[j], types[k], types[l]),
                 parameters_type,
@@ -729,4 +743,9 @@ class EEX_Mixin:
 
     def eex_compare_values(self, old, new):
         """Compare parameters values to see if they are the same."""
+        if self.ff_form == "class2":
+            # Lammps class2 relies on having all the angles, torsions, and oops
+            # for the cross terms to match.
+            return old == new
+
         return old[0] == new[0] and old[1] == new[1] and old[4] == new[4]

--- a/tests/test_angle-angle_parameters.py
+++ b/tests/test_angle-angle_parameters.py
@@ -13,7 +13,10 @@ def test_angle_angle_explicit(pcff):
     expected = {
         "Theta10": "107.6600",
         "Theta20": "105.8500",
+        "original Theta10": "107.6600",
+        "original Theta20": "105.8500",
         "reference": "1",
+        "version": "1.0",
         "K": "3.5475",
         "original K": "3.5475",
     }
@@ -48,7 +51,10 @@ def test_angle_angle_equivalent(pcff):
     expected = {
         "Theta10": "116.0640",
         "Theta20": "116.0640",
+        "original Theta10": "116.0640",
+        "original Theta20": "116.0640",
         "reference": "6",
+        "version": "2.1",
         "K": "5.9863",
         "original K": "5.9863",
     }

--- a/tests/test_angle_angle_torsion_1_parameters.py
+++ b/tests/test_angle_angle_torsion_1_parameters.py
@@ -14,7 +14,10 @@ def test_angle_angle_torsion_1_explicit(pcff):
     expected = {
         "Theta0_L": "110.7700",
         "Theta0_R": "108.4000",
+        "original Theta0_L": "110.7700",
+        "original Theta0_R": "108.4000",
         "reference": "1",
+        "version": "1.0",
         "K": "-14.3155",
         "original K": "-14.3155",
     }
@@ -37,7 +40,10 @@ def test_angle_angle_torsion_1_explicit_lkji(pcff):
     expected = {
         "Theta0_L": "108.4000",
         "Theta0_R": "110.7700",
+        "original Theta0_L": "108.4000",
+        "original Theta0_R": "110.7700",
         "reference": "1",
+        "version": "1.0",
         "K": "-14.3155",
         "original K": "-14.3155",
     }
@@ -60,7 +66,10 @@ def test_angle_angle_torsion_1_equivalent(pcff):
     expected = {
         "Theta0_L": "111.0000",
         "Theta0_R": "120.0500",
+        "original Theta0_L": "111.0000",
+        "original Theta0_R": "120.0500",
         "reference": "1",
+        "version": "1.0",
         "K": "-5.8888",
         "original K": "-5.8888",
     }

--- a/tests/test_angle_parameters.py
+++ b/tests/test_angle_parameters.py
@@ -13,6 +13,7 @@ def test_angle_explicit(pcff):
 
     expected = {
         "reference": "8",
+        "version": "2.1",
         "Theta0": "106.9999",
         "original Theta0": "106.9999",
         "K2": "46.0608",
@@ -51,6 +52,7 @@ def test_angle_equivalent(pcff):
     """Simple test of angle parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "1.0",
         "Theta0": "117.9400",
         "original Theta0": "117.9400",
         "K2": "35.1558",
@@ -76,6 +78,7 @@ def test_angle_auto(pcff):
     """test of angle parameters using automatic parameters"""
     expected = {
         "reference": "2",
+        "version": "2.0",
         "Theta0": "120.0000",
         "original Theta0": "120.0000",
         "K2": "80.0000",

--- a/tests/test_angle_torsion_3_parameters.py
+++ b/tests/test_angle_torsion_3_parameters.py
@@ -12,15 +12,24 @@ def test_angle_torsion_3_explicit(pcff):
     explicit ones"""
 
     expected = {
-        "V1_L": "0.0492",
-        "V1_R": "-1.6930",
-        "V2_L": "0.7162",
-        "V2_R": "-0.6252",
-        "V3_L": "-0.2277",
-        "V3_R": "-0.2148",
         "reference": "1",
+        "version": "1.0",
+        "V1_L": "0.0492",
+        "V2_L": "0.7162",
+        "V3_L": "-0.2277",
+        "V1_R": "-1.6930",
+        "V2_R": "-0.6252",
+        "V3_R": "-0.2148",
         "Theta0_L": "108.4000",
         "Theta0_R": "110.7700",
+        "original V1_L": "0.0492",
+        "original V2_L": "0.7162",
+        "original V3_L": "-0.2277",
+        "original V1_R": "-1.6930",
+        "original V2_R": "-0.6252",
+        "original V3_R": "-0.2148",
+        "original Theta0_L": "108.4000",
+        "original Theta0_R": "110.7700",
     }
 
     i = "h"
@@ -30,6 +39,8 @@ def test_angle_torsion_3_explicit(pcff):
     ptype, key, form, parameters = pcff.angle_torsion_3_parameters(i, j, k, l)
     assert ptype == "explicit"
     assert key == ("h", "c", "c", "c_0")
+    if parameters != expected:
+        print(json.dumps(parameters, indent=4))
     assert parameters == expected
 
 
@@ -38,6 +49,7 @@ def test_angle_torsion_3_explicit_kji(pcff):
 
     expected = {
         "reference": "1",
+        "version": "1.0",
         "V1_L": "-1.6930",
         "original V1_L": "-1.6930",
         "V2_L": "-0.6252",
@@ -52,6 +64,8 @@ def test_angle_torsion_3_explicit_kji(pcff):
         "original V3_R": "-0.2277",
         "Theta0_L": "108.4000",
         "Theta0_R": "110.7700",
+        "original Theta0_L": "108.4000",
+        "original Theta0_R": "110.7700",
     }
 
     i = "c_0"
@@ -71,6 +85,7 @@ def test_angle_torsion_3_equivalent(pcff):
 
     expected = {
         "reference": "1",
+        "version": "1.0",
         "V1_L": "4.6266",
         "original V1_L": "4.6266",
         "V2_L": "0.1632",
@@ -85,6 +100,8 @@ def test_angle_torsion_3_equivalent(pcff):
         "original V3_R": "0.1237",
         "Theta0_L": "111.0000",
         "Theta0_R": "120.0500",
+        "original Theta0_L": "111.0000",
+        "original Theta0_R": "120.0500",
     }
 
     i = "h"

--- a/tests/test_bond-bond_1_3_parameters.py
+++ b/tests/test_bond-bond_1_3_parameters.py
@@ -14,6 +14,7 @@ def test_bond_bond_1_3_explicit(pcff):
         "R10": "1.1010",
         "R30": "1.4170",
         "reference": "1",
+        "version": "1.0",
         "K": "-3.4826",
         "original K": "-3.4826",
     }
@@ -49,6 +50,7 @@ def test_bond_bond_1_3_equivalent(pcff):
         "R10": "1.1010",
         "R30": "1.4170",
         "reference": "1",
+        "version": "1.0",
         "K": "-3.4826",
         "original K": "-3.4826",
     }

--- a/tests/test_bond-bond_parameters.py
+++ b/tests/test_bond-bond_parameters.py
@@ -12,8 +12,11 @@ def test_bond_bond_explicit(pcff):
 
     expected = {
         "R10": "1.5300",
+        "original R10": "1.5300",
         "R20": "1.1010",
+        "original R20": "1.1010",
         "reference": "1",
+        "version": "1.0",
         "K": "3.3872",
         "original K": "3.3872",
     }
@@ -38,6 +41,11 @@ def test_bond_bond_explicit_kji(pcff):
     ptype2, key2, form, parameters2 = pcff.bond_bond_parameters(k, j, i)
     assert ptype2 == "explicit"
     assert key2 == ("c", "c", "h")
+    if parameters != parameters2:
+        print("parameters=")
+        print(json.dumps(parameters, indent=4))
+        print("not equal to parameters2=")
+        print(json.dumps(parameters2, indent=4))
     assert parameters == parameters2
 
 
@@ -45,8 +53,11 @@ def test_bond_bond_equivalent(pcff):
     """Simple test of bond_bond parameters using equivalencies"""
     expected = {
         "R10": "1.5300",
+        "original R10": "1.5300",
         "R20": "1.1010",
+        "original R20": "1.1010",
         "reference": "1",
+        "version": "1.0",
         "K": "3.3872",
         "original K": "3.3872",
     }

--- a/tests/test_bond_angle_parameters.py
+++ b/tests/test_bond_angle_parameters.py
@@ -12,6 +12,7 @@ def test_bond_angle_explicit(pcff):
 
     expected = {
         "reference": "1",
+        "version": "1.0",
         "K12": "20.7540",
         "original K12": "20.7540",
         "K23": "11.4210",
@@ -35,11 +36,16 @@ def test_bond_angle_explicit_kji(pcff):
     """known bond_angle parameters, ordered backwards"""
 
     expected = {
+        "reference": "1",
+        "version": "1.0",
         "K12": "11.4210",
         "K23": "20.7540",
-        "reference": "1",
         "R10": "1.5300",
         "R20": "1.1010",
+        "original K12": "11.4210",
+        "original K23": "20.7540",
+        "original R10": "1.5300",
+        "original R20": "1.1010",
     }
     i = "h"
     j = "c"
@@ -47,6 +53,8 @@ def test_bond_angle_explicit_kji(pcff):
     ptype, key, form, parameters = pcff.bond_angle_parameters(i, j, k)
     assert ptype == "explicit"
     assert key == ("h", "c", "c")
+    if parameters != expected:
+        print(json.dumps(parameters, indent=4))
     assert parameters == expected
 
 
@@ -54,12 +62,15 @@ def test_bond_angle_equivalent(pcff):
     """Simple test of bond_angle parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "1.0",
         "K12": "20.7540",
         "original K12": "20.7540",
         "K23": "11.4210",
         "original K23": "11.4210",
         "R10": "1.5300",
         "R20": "1.1010",
+        "original R10": "1.1010",
+        "original R20": "1.5300",
     }
 
     i = "c"

--- a/tests/test_bond_parameters.py
+++ b/tests/test_bond_parameters.py
@@ -11,6 +11,7 @@ def test_bond_explicit(pcff):
     """Simple test of known bond parameters"""
     expected = {
         "reference": "8",
+        "version": "2.1",
         "R0": "1.1010",
         "original R0": "1.1010",
         "K2": "345.0000",
@@ -46,6 +47,7 @@ def test_bond_equivalent(pcff):
     """Simple test of bond parameters using equivalencies"""
     expected = {
         "reference": "8",
+        "version": "2.1",
         "R0": "1.0982",
         "original R0": "1.0982",
         "K2": "372.8251",
@@ -70,6 +72,7 @@ def test_bond_auto(pcff):
     """Simple test of bond parameters using automatic parameters"""
     expected = {
         "reference": "2",
+        "version": "2.0",
         "R0": "1.9200",
         "original R0": "1.9200",
         "K2": "223.6000",

--- a/tests/test_end_bond_torsion_3_parameters.py
+++ b/tests/test_end_bond_torsion_3_parameters.py
@@ -12,15 +12,24 @@ def test_end_bond_torsion_3_explicit(pcff):
     explicit ones"""
 
     expected = {
-        "V1_L": "0.0870",
-        "V1_R": "0.2217",
-        "V2_L": "0.5143",
-        "V2_R": "0.4780",
-        "V3_L": "-0.2448",
-        "V3_R": "-0.0817",
         "reference": "1",
+        "version": "1.0",
+        "V1_L": "0.0870",
+        "V2_L": "0.5143",
+        "V3_L": "-0.2448",
+        "V1_R": "0.2217",
+        "V2_R": "0.4780",
+        "V3_R": "-0.0817",
         "R0_L": "1.5140",
         "R0_R": "1.1010",
+        "original V1_L": "0.0870",
+        "original V2_L": "0.5143",
+        "original V3_L": "-0.2448",
+        "original V1_R": "0.2217",
+        "original V2_R": "0.4780",
+        "original V3_R": "-0.0817",
+        "original R0_L": "1.5140",
+        "original R0_R": "1.1010",
     }
 
     i = "h"
@@ -40,6 +49,7 @@ def test_end_bond_torsion_3_explicit_kji(pcff):
 
     expected = {
         "reference": "1",
+        "version": "1.0",
         "V1_L": "0.2217",
         "original V1_L": "0.2217",
         "V2_L": "0.4780",
@@ -54,6 +64,8 @@ def test_end_bond_torsion_3_explicit_kji(pcff):
         "original V3_R": "-0.2448",
         "R0_L": "1.5140",
         "R0_R": "1.1010",
+        "original R0_L": "1.5140",
+        "original R0_R": "1.1010",
     }
 
     i = "c_0"
@@ -72,6 +84,7 @@ def test_end_bond_torsion_3_equivalent(pcff):
     """Simple test of end_bond_torsion_3 parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "1.0",
         "V1_L": "1.3997",
         "original V1_L": "1.3997",
         "V2_L": "0.7756",
@@ -86,6 +99,8 @@ def test_end_bond_torsion_3_equivalent(pcff):
         "original V3_R": "0.3978",
         "R0_L": "1.1010",
         "R0_R": "1.4170",
+        "original R0_L": "1.1010",
+        "original R0_R": "1.4170",
     }
 
     i = "h"

--- a/tests/test_middle_bond_torsion_3_parameters.py
+++ b/tests/test_middle_bond_torsion_3_parameters.py
@@ -14,6 +14,7 @@ def test_middle_bond_torsion_3_explicit(pcff):
     expected = {
         "R0": "1.5300",
         "reference": "1",
+        "version": "1.0",
         "V1": "-10.0179",
         "original V1": "-10.0179",
         "V2": "-2.8145",
@@ -40,6 +41,7 @@ def test_middle_bond_torsion_3_explicit_lkji(pcff):
     expected = {
         "R0": "1.5300",
         "reference": "1",
+        "version": "1.0",
         "V1": "-10.0179",
         "original V1": "-10.0179",
         "V2": "-2.8145",
@@ -65,6 +67,7 @@ def test_middle_bond_torsion_3_equivalent(pcff):
     expected = {
         "R0": "1.5010",
         "reference": "1",
+        "version": "1.0",
         "V1": "-5.5679",
         "original V1": "-5.5679",
         "V2": "1.4083",

--- a/tests/test_nonbond_parameters.py
+++ b/tests/test_nonbond_parameters.py
@@ -11,6 +11,7 @@ def test_nonbond_explicit(pcff):
     """Simple test of known nonbond parameters"""
     expected = {
         "reference": "1",
+        "version": "2.0",
         "rmin": 2.995,
         "eps": 0.02,
         "original rmin": "2.9950",
@@ -30,6 +31,7 @@ def test_nonbond_equivalent(pcff):
     """Simple test of nonbond parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "2.0",
         "rmin": 4.01,
         "eps": 0.064,
         "original rmin": "4.0100",

--- a/tests/test_oop_parameters.py
+++ b/tests/test_oop_parameters.py
@@ -12,6 +12,7 @@ def test_oop_explicit(pcff):
 
     expected = {
         "reference": "1",
+        "version": "1.0",
         "K": "10.8102",
         "original K": "10.8102",
         "Chi0": "0.0000",
@@ -47,6 +48,7 @@ def test_oop_equivalent(pcff):
     """Simple test of out-of-plane parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "1.0",
         "K": "10.8102",
         "original K": "10.8102",
         "Chi0": "0.0000",
@@ -69,6 +71,7 @@ def test_oop_auto(pcff):
     """test of out-of-plane parameters using automatic parameters"""
     expected = {
         "reference": "1",
+        "version": "2.0",
         "K": "36.0000",
         "original K": "36.0000",
         "Chi0": "0.0000",

--- a/tests/test_torsion_parameters.py
+++ b/tests/test_torsion_parameters.py
@@ -12,6 +12,7 @@ def test_torsion_explicit(pcff):
 
     expected = {
         "reference": "8",
+        "version": "2.1",
         "V1": "0.0000",
         "original V1": "0.0000",
         "Phi0_1": "0.0",
@@ -55,6 +56,7 @@ def test_torsion_equivalent(pcff):
     """Simple test of torsion parameters using equivalencies"""
     expected = {
         "reference": "1",
+        "version": "1.0",
         "V1": "0.0000",
         "original V1": "0.0000",
         "Phi0_1": "0.0",
@@ -85,6 +87,7 @@ def test_torsion_auto(pcff):
     """test of torsion parameters using automatic parameters"""
     expected = {
         "reference": "2",
+        "version": "2.0",
         "KPhi": "3.0000",
         "original KPhi": "3.0000",
         "n": "2",


### PR DESCRIPTION
* Added tracking of the original parameters for cross terms like bond-bond terms.
* Improved chacking for duplicate parameters to remove most duplicates, except for class 2 forcefields, where the cross terms must have the same terms as the diagonal time, i.e. angle and bond-bond terms must share a list of angles.