### PR TITLE
Bugfix: tabulated angles cause a crash

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 =======
 History
 =======
+2025.8.1 -- Bugfix: tabulated angles cause a crash
+   * The changes for tracking the original parameters introduced an error into the code
+     handling tabulated angles. This is now fixed.
+   * Added the element symbol corresponding to the atom type in the energy
+     expression. This allows LAMMPS to add the correct element symbol to trajectories,
+     if desired.
+
 2025.5.26 -- Track more of the original parameters
    * Added tracking of the original parameters for cross terms like bond-bond terms.
    * Improved chacking for duplicate parameters to remove most duplicates, except for

--- a/seamm_ff_util/eex.py
+++ b/seamm_ff_util/eex.py
@@ -128,6 +128,7 @@ class EEX_Mixin:
         result = eex["atoms"] = []
         atom_types = eex["atom types"] = []
         masses = eex["masses"] = []
+        elements = eex["elements"] = []
 
         shells = []
         eex["shell_of_atom"] = shell_of_atom = []
@@ -141,6 +142,7 @@ class EEX_Mixin:
                     atom_types.append(itype)
                     index = len(atom_types)
                     masses.append((self.mass(itype), itype))
+                    elements.append(self.element(itype))
                 result.append((x, y, z, index))
                 shell_of_atom.append(None)
             else:
@@ -157,6 +159,7 @@ class EEX_Mixin:
                     atom_types.append("core_" + itype)
                     index = len(atom_types)
                     masses.append((0.9 * float(self.mass(itype)), "core_" + itype))
+                    elements.append(self.element(itype))
                     result.append((x, y, z, index))
                     # shell
                     atom_types.append(itype)

--- a/seamm_ff_util/forcefield.py
+++ b/seamm_ff_util/forcefield.py
@@ -1398,6 +1398,17 @@ class Forcefield(EEX_Mixin, DreidingMixin, ReaxFFMixin):
                 if key is not None:
                     newdata[item] = data[item][key]
 
+    def element(self, i):
+        """Return the element symbol for an atom type i"""
+        if self.ff_form == "reaxff":
+            if (i,) in self.ff["reaxff_atomic_parameters_25-32"]:
+                return i
+
+        if i in self.ff["atom_types"]:
+            return self.ff["atom_types"][i]["element"]
+
+        raise RuntimeError("no atom type data for {}".format(i))
+
     def mass(self, i):
         """Return the atomic mass for an atom type i"""
         if self.ff_form == "reaxff":

--- a/seamm_ff_util/tabulate_function.py
+++ b/seamm_ff_util/tabulate_function.py
@@ -29,19 +29,28 @@ def tabulate_angle(equation, values, derivative=None, step=0.2):
     if "zero-shift" in values:
         thetas[0] += values.pop("zero-shift")
 
-    symbols = [sympy.symbols(key) for key in values.keys()]
+    variables = []
+    filtered_values = {}
+    for key in values.keys():
+        if key.startswith("original "):
+            continue
+        if key in ("version",):
+            continue
+        variables.append(key)
+        filtered_values[key] = values[key]
+    symbols = [sympy.symbols(key) for key in variables]
     Theta = sympy.symbols("Theta")
     symbols.append(Theta)
     eqn = sympy.parse_expr(equation)
     E = sympy.lambdify(symbols, eqn, "numpy")
 
-    Es = E(**values, Theta=np.radians(thetas))
+    Es = E(**filtered_values, Theta=np.radians(thetas))
     if derivative is None:
         deqn = sympy.diff(eqn, Theta)
     else:
         deqn = sympy.parse_expr(derivative)
     dE = sympy.lambdify(symbols, deqn, "numpy")
-    dEs = dE(**values, Theta=np.radians(thetas))
+    dEs = dE(**filtered_values, Theta=np.radians(thetas))
 
     # Undo any shift
     thetas[0] = 0.0


### PR DESCRIPTION
   
* The changes for tracking the original parameters introduced an error into the code handling tabulated angles. This is now fixed.
* Added the element symbol corresponding to the atom type in the energy expression. This allows LAMMPS to add the correct element symbol to trajectories, if desired.